### PR TITLE
Added DNS TTL support

### DIFF
--- a/lib/AnyEvent/CacheDNS.pm
+++ b/lib/AnyEvent/CacheDNS.pm
@@ -4,8 +4,6 @@ use strict;
 use warnings;
 use base 'AnyEvent::DNS';
 
-use Data::Dumper;
-
 our $VERSION = '0.05';
 
 # Detect AnyEvent >= 6.0.1

--- a/t/dns.t
+++ b/t/dns.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 11;
 
 use AnyEvent;
 use AnyEvent::CacheDNS ':register';
@@ -65,7 +65,9 @@ sub main {
 
 	# Check that the cache as a DNS record
 	ok(pop @{ $cached }, "IP address is true");
-	is_deeply($cached, [$host, 'a', 'in'], "DNS response matches");
+	ok($cached->[0] eq $host, "Response packet host matches");
+	ok($cached->[1] eq 'a', "Response packet record type matches");
+	ok($cached->[2] eq 'in', "Response packet record class matches");
 
 	return 0;
 }

--- a/t/dns.t
+++ b/t/dns.t
@@ -8,8 +8,6 @@ use Test::More tests => 11;
 use AnyEvent;
 use AnyEvent::CacheDNS ':register';
 use AnyEvent::DNS;
-use Data::Dumper;
-
 
 sub main {
 


### PR DESCRIPTION
Attached patch adds AnyEvent 6.x DNS TTL parameter support while adding ability to purge records from cache after certain amount of time in AnyEvent 5.x.

I also fixed tests failing under AnyEvent 6.x
