### PR TITLE
Fix for case of not existent domain and new AnyEvent

### DIFF
--- a/lib/AnyEvent/CacheDNS.pm
+++ b/lib/AnyEvent/CacheDNS.pm
@@ -55,13 +55,10 @@ sub resolve {
 			$cache->{$qname} ||= @_ ? $_[0] : undef;
 
 			# Respect TTL and be backwards compatible with AnyEvent < 6.x
-			my $ttl;
-			if ($IS_AE_6X) {
-				$ttl = defined $DEFAULT_TTL ? $DEFAULT_TTL : int($_[0]->[3] || 0);
-			}
-			else {
-				$ttl = defined $DEFAULT_TTL ? $DEFAULT_TTL : 0;
-			}
+			my $ttl =
+				defined $DEFAULT_TTL ? $DEFAULT_TTL :
+				$IS_AE_6X && @_ ? int($_[0]->[3] || 0) :
+				0;
 
 			if ($ttl > 0) {
 				# Create expire timer


### PR DESCRIPTION
Expression "$_[0]->[3]" changes variable @_, if its empty, so we pass incorrect data to callback
Problem appears on ipv4/ipv6 environment, when target domain has not AAAA record
